### PR TITLE
Fix issue where layer doesn't have getBounds as a function property

### DIFF
--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -167,9 +167,11 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
             if(layer){
               var hasLayer = this._map.hasLayer(layer);
               var hadBounds = layer.getBounds;
-              var boundsInMap = mapBounds.intersects(layer.getBounds());
-              if(this._map.hasLayer(layer) && (!hadBounds || !(hadBounds && boundsInMap))){
-                this._map.removeLayer(layer);
+              if (hadBounds) {
+                var boundsInMap = mapBounds.intersects(layer.getBounds());
+                if(hasLayer && (!hadBounds || !(hadBounds && boundsInMap))){
+                  this._map.removeLayer(layer);
+                }
               }
             }
           }


### PR DESCRIPTION
https://github.com/Esri/esri-leaflet/pull/411 looks good so far. I wish I could test it more but our internal feature services are super slow today. I'll definitely revisit this throughout next week.
.
Btw, I was getting an error where layer.getBounds() would return undefined that's why I added additional hadBounds check

And, as you probably already know, some tests are failing. I may look into fixing the tests as well if time permits.
